### PR TITLE
Add Sphinx documentation and publish to ReadTheDocs

### DIFF
--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout redata-commons
+    - name: Checkout ldcoolp-figshare
       uses: actions/checkout@v2
     - name: Sphinx build
       uses: ammaraskar/sphinx-action@master

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -1,0 +1,24 @@
+name: "Sphinx Docs Check"
+on:
+  push:
+    paths:
+    - 'docs/**'
+    - 'ldcoolp_figshare/**'
+    - '.github/workflows/sphinx*yml'
+  pull_request:
+    paths:
+    - 'docs/**'
+    - 'ldcoolp_figshare/**'
+    - '.github/workflows/sphinx*yml'
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout redata-commons
+      uses: actions/checkout@v2
+    - name: Sphinx build
+      uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "docs/"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx>=4.0
+sphinx-rtd-theme==0.5.2
+sphinx-autodoc-typehints==1.12.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
+redata>=0.4.0
+
 sphinx>=4.0
 sphinx-rtd-theme==0.5.2
 sphinx-autodoc-typehints==1.12.0

--- a/docs/source/authors.rst
+++ b/docs/source/authors.rst
@@ -1,0 +1,12 @@
+Authors
+-------
+
+-  Chun Ly, Ph.D. (`@astrochun`_) -
+   `University of Arizona Libraries`_,
+   `Office of Digital Innovation and Stewardship`_
+
+See also the list of :repo:`contributors <contributors>` who participated in this project.
+
+.. _@astrochun: http://www.github.com/astrochun
+.. _University of Arizona Libraries: https://github.com/ualibraries
+.. _Office of Digital Innovation and Stewardship: https://github.com/UAL-ODIS

--- a/docs/source/ci.rst
+++ b/docs/source/ci.rst
@@ -1,0 +1,4 @@
+Continuous Integration
+----------------------
+
+Under construction.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,69 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+import sphinx_rtd_theme
+import sphinx_autodoc_typehints
+sys.path.insert(0, os.path.abspath('../../'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'ldcoolp-figshare'
+copyright = '2021, Arizona Board of Regents'
+author = 'Chun Ly, UA Research Data Repository (ReDATA) Team'
+
+# The full version, including alpha/beta/rc tags
+release = 'v0.1.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx_rtd_theme",
+    "sphinx.ext.autodoc",
+    "sphinx_autodoc_typehints",
+    "sphinx.ext.extlinks",
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+# -- External links for repeated use:
+repo_link = 'https://github.com/UAL-ODIS/ldcoolp-figshare'
+extlinks = {
+    'repo': (f"{repo_link}/%s", None),
+    'repo-main-file': (f"{repo_link}/blob/main/%s", None),
+    'pypi': ('https://pypi.org/project/ldcoolp-figshare/%s', None),
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,6 +47,9 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+# If true, the current module name will be prepended to all description
+# unit titles (such as .. function::).
+add_module_names = False
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/source/execution.rst
+++ b/docs/source/execution.rst
@@ -1,4 +1,0 @@
-Execution
----------
-
-Under construction.

--- a/docs/source/execution.rst
+++ b/docs/source/execution.rst
@@ -1,0 +1,4 @@
+Execution
+---------
+
+Under construction.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -1,0 +1,17 @@
+Getting Started
+---------------
+
+You will need Python. We recommend v3.9. This code will be tested with
+v3.7, v3.8, and v3.9.
+
+This code will be published as ``ldcoolp-figshare`` on PyPI. Thus, the
+simplest installation will be:
+
+::
+
+   pip install ldcoolp-figshare
+
+Requirements
+~~~~~~~~~~~~
+
+All requirements will be given in the :repo-main-file:`requirements.txt <requirements.txt>`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,5 +45,4 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,48 @@
+.. ldcoolp-figshare documentation master file, created by
+   sphinx-quickstart on Tue May 18 15:55:23 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to :repo:`ldcoolp-figshare <>` documentation!
+=====================================================
+
+|GitHub top language| |GitHub release (latest by date)| |GitHub|
+
+--------------
+
+Overview
+--------
+
+``ldcoolp-figshare`` is a command-line API used in `LD-Cool-P`_ to
+interact with the `Figshare API`_. It is used by `ReDATA`_ data curators
+for the curation of submitted research data products. This codebase is
+generalized such that other curators with a `Figshare for Institution`_
+instance can use.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   getting_started
+   execution
+   ci
+   versioning
+   authors
+   license
+
+.. |GitHub top language| image:: https://img.shields.io/github/languages/top/UAL-ODIS/ldcoolp-figshare
+.. |GitHub release (latest by date)| image:: https://img.shields.io/github/v/release/UAL-ODIS/ldcoolp-figshare
+.. |GitHub| image:: https://img.shields.io/github/license/UAL-ODIS/ldcoolp-figshare?color=blue
+
+.. _LD-Cool-P: https://github.com/UAL-ODIS/LD_Cool_P
+.. _Figshare API: https://api.figshare.com
+.. _ReDATA: https://arizona.figshare.com
+.. _Figshare for Institution: https://knowledge.figshare.com/institutions
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,6 +29,7 @@ instance can use.
    versioning
    authors
    license
+   modules
 
 .. |GitHub top language| image:: https://img.shields.io/github/languages/top/UAL-ODIS/ldcoolp-figshare
 .. |GitHub release (latest by date)| image:: https://img.shields.io/github/v/release/UAL-ODIS/ldcoolp-figshare

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,7 +24,7 @@ instance can use.
    :caption: Contents:
 
    getting_started
-   execution
+   use_examples
    ci
    versioning
    authors

--- a/docs/source/ldcoolp_figshare.rst
+++ b/docs/source/ldcoolp_figshare.rst
@@ -4,8 +4,8 @@ ldcoolp-figshare package
 .. toctree::
    :maxdepth: 4
 
-Primary Class
--------------
+The ``FigshareInstituteAdmin`` Class
+------------------------------------
 
 .. autoclass:: ldcoolp_figshare.FigshareInstituteAdmin
    :members:

--- a/docs/source/ldcoolp_figshare.rst
+++ b/docs/source/ldcoolp_figshare.rst
@@ -1,0 +1,13 @@
+ldcoolp-figshare package
+========================
+
+.. toctree::
+   :maxdepth: 4
+
+Primary Class
+-------------
+
+.. autoclass:: ldcoolp_figshare.FigshareInstituteAdmin
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -1,0 +1,7 @@
+License
+-------
+
+This project is licensed under the `MIT License`_ - see the :repo-main-file:`LICENSE <LICENSE>`
+file for details.
+
+.. _MIT License: https://opensource.org/licenses/MIT

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,7 @@
+API Documentation
+=================
+
+.. toctree::
+   :maxdepth: 2
+
+   ldcoolp_figshare

--- a/docs/source/use_examples.rst
+++ b/docs/source/use_examples.rst
@@ -1,0 +1,96 @@
+Use Examples
+------------
+
+The primary class/object that is used for all interactions with the Figshare API is
+:doc:`FigshareInstituteAdmin </ldcoolp_figshare>`. Below are for how to use
+this API:
+
+.. code-block:: python
+
+    from ldcoolp_figshare import FigshareInstituteAdmin
+
+    token = "***ENTER YOUR API KEY ***"
+    stage = False  # Set to False (True) for production (stage) instance
+
+    fs_admin = FigshareInstituteAdmin(token=token, stage=stage)
+
+
+There are several methods available with ``FigshareInstituteAdmin``.
+We refer users to the full API documentation for more details.
+Below we provide some examples to get users started.
+
+Get a list of accounts
+~~~~~~~~~~~~~~~~~~~~~~
+To retrieve a list of accounts for an institution:
+
+.. code-block:: python
+
+    fs_admin.get_account_list()
+
+Note that this provides you with the ``account_id`` of a user
+
+
+Obtain curation records
+~~~~~~~~~~~~~~~~~~~~~~~
+To retrieve a full list of curation records (of any state) for an institution:
+
+.. code-block:: python
+
+    curation_df = fs_admin.get_curation_list()
+
+If you wish to retrieve all curation records for a specific item/deposit,
+then provide the ``article_id``:
+
+.. code-block:: python
+
+    article_id = 12345678
+    article_curation_df = fs_admin.get_curation_list(article_id)
+
+
+To obtain more information about a specific curation record:
+
+.. code-block:: python
+
+    curation_id = 1234567
+    details_dict = fs_admin.get_curation_details(curation_id)
+
+
+DOI status and reservation
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To check if a DOI is reserved for an item/deposit:
+
+.. code-block:: python
+
+    article_id = 12345678
+    check, DOI_string = fs_admin.doi_check(article_id)
+
+
+Here, ``check`` will either be ``False`` (no DOI) or ``True``.
+
+Alternatively, you can reserve a DOI if it hasn't been done so.
+This will provide an prompt before performing the task.
+**Note: This step is irreversible!**
+
+.. code-block:: python
+
+    article_id = 12345678
+    check, DOI_string = fs_admin.reserve_doi(article_id)
+
+
+Retrieve list of institution groups
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    group_df = fs_admin.get_groups()
+
+
+
+Retrieve list of articles for a user
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    account_id = 98765432
+    article_df = fs_admin.get_user_articles(account_id)

--- a/docs/source/versioning.rst
+++ b/docs/source/versioning.rst
@@ -1,0 +1,11 @@
+Versioning
+----------
+
+We use `SemVer`_ for versioning. For the versions available, see the
+:repo:`tags <tags on this repository>`.
+
+Releases will be auto-generated using this
+:repo-main-file:`GitHub Actions script <.github/workflows/create_release.yml>`
+following a ``git tag vX.Y.Z``.
+
+.. _SemVer: http://semver.org/

--- a/ldcoolp_figshare/__init__.py
+++ b/ldcoolp_figshare/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.3"
+__version__ = "0.1.0"
 
 from .main import FigshareInstituteAdmin

--- a/ldcoolp_figshare/main.py
+++ b/ldcoolp_figshare/main.py
@@ -17,7 +17,7 @@ class FigshareInstituteAdmin:
     Most methods take a ``article_id`` or ``curation_id`` input
 
     :param token: Figshare OAuth2 authentication token
-    :param stage: Flag to either use Figshare stage or prod API
+    :param stage: Flag to either use Figshare stage or production API. Default: production
     :param admin_filter: List of filters to remove admin accounts from user list
     :param log: Logger object for stdout and file logging. Default: stdout
 
@@ -25,7 +25,6 @@ class FigshareInstituteAdmin:
     :ivar stage: Flag to either use Figshare stage or prod API
     :ivar baseurl: Base URL of Figshare API
     :ivar baseurl_institute: Base URL of Figshare API for institutions
-    :ivar token: Figshare OAuth2 authentication token
     :ivar headers: HTTP header information
     :ivar admin_filter: List of filters to remove admin accounts from user list
     :ivar ignore_admin: Flags whether to remove admin accounts from user list
@@ -57,7 +56,7 @@ class FigshareInstituteAdmin:
         self.log = log
 
     def endpoint(self, link: str, institute: bool = True) -> str:
-        """Concatenate the endpoint to the baseurl"""
+        """Concatenate the endpoint to the baseurl for ``requests``"""
         if institute:
             return self.baseurl_institute + link
         else:
@@ -66,6 +65,7 @@ class FigshareInstituteAdmin:
     def get_articles(self) -> pd.DataFrame:
         """
         Retrieve information about all articles within institutional instance
+
         See: https://docs.figshare.com/#private_institution_articles
         """
 
@@ -81,8 +81,9 @@ class FigshareInstituteAdmin:
 
     def get_user_articles(self, account_id: int) -> pd.DataFrame:
         """
-        Impersonate a user, ``account_id`, to retrieve articles
+        Impersonate a user, ``account_id``, to retrieve articles
         associated with the user.
+
         See: https://docs.figshare.com/#private_articles_list
         """
 
@@ -97,8 +98,9 @@ class FigshareInstituteAdmin:
 
     def get_user_projects(self, account_id: int) -> pd.DataFrame:
         """
-        Impersonate a user, ``account_id`, to retrieve projects
+        Impersonate a user, ``account_id``, to retrieve projects
         associated with the user.
+
         See: https://docs.figshare.com/#private_projects_list
         """
 
@@ -115,6 +117,7 @@ class FigshareInstituteAdmin:
         """
         Impersonate a user, ``account_id``, to retrieve collections
         associated with the user.
+
         See: https://docs.figshare.com/#private_collections_list
         """
 
@@ -130,6 +133,7 @@ class FigshareInstituteAdmin:
     def get_groups(self) -> pd.DataFrame:
         """
         Retrieve information about groups within institutional instance.
+
         See: https://docs.figshare.com/#private_institution_groups_list
         """
 
@@ -142,6 +146,7 @@ class FigshareInstituteAdmin:
     def get_account_list(self) -> pd.DataFrame:
         """
         Return pandas DataFrame of user accounts.
+
         See: https://docs.figshare.com/#private_institution_accounts_list
         """
 
@@ -168,6 +173,7 @@ class FigshareInstituteAdmin:
     def get_account_group_roles(self, account_id: int) -> dict:
         """
         Retrieve group roles for a given account, ``account_id``.
+
         See: https://docs.figshare.com/#private_institution_account_group_roles
         """
 
@@ -257,6 +263,7 @@ class FigshareInstituteAdmin:
         """
         Retrieve list of curation records for ``article_id``.
         If not specified, all curation records are retrieved.
+
         See: https://docs.figshare.com/#account_institution_curations
         """
 
@@ -275,6 +282,7 @@ class FigshareInstituteAdmin:
     def get_curation_details(self, curation_id: int) -> dict:
         """
         Retrieve details about a specified curation, ``curation_id``.
+
         See: https://docs.figshare.com/#account_institution_curation
         """
 
@@ -285,7 +293,8 @@ class FigshareInstituteAdmin:
 
     def get_curation_comments(self, curation_id: int) -> dict:
         """
-        Retrieve comments about specified curation, ``curation_id`.
+        Retrieve comments about specified curation, ``curation_id``.
+
         See: https://docs.figshare.com/#account_institution_curation_comments
         """
 
@@ -297,6 +306,7 @@ class FigshareInstituteAdmin:
     def doi_check(self, article_id: int) -> Tuple[bool, str]:
         """
         Check if DOI is present/reserved for ``article_id``.
+
         Uses: https://docs.figshare.com/#private_article_details
         """
         url = self.endpoint(f"articles/{article_id}", institute=False)

--- a/ldcoolp_figshare/main.py
+++ b/ldcoolp_figshare/main.py
@@ -14,7 +14,7 @@ class FigshareInstituteAdmin:
     A Python interface for administration and data curation
     with institutional Figshare instances
 
-    Most methods take a ``article_id`` or ``curation_id`` input
+    Most methods take an ``article_id`` or ``curation_id`` input
 
     :param token: Figshare OAuth2 authentication token
     :param stage: Flag to either use Figshare stage or production API. Default: production
@@ -56,7 +56,13 @@ class FigshareInstituteAdmin:
         self.log = log
 
     def endpoint(self, link: str, institute: bool = True) -> str:
-        """Concatenate the endpoint to the baseurl for ``requests``"""
+        """Concatenate the endpoint to the baseurl for ``requests``
+
+        :param link: API endpoint to append to baseurl
+        :param institute: Flag to use regular of institute baseurl
+
+        :return: URL for HTTPS API
+        """
         if institute:
             return self.baseurl_institute + link
         else:
@@ -67,6 +73,8 @@ class FigshareInstituteAdmin:
         Retrieve information about all articles within institutional instance
 
         See: https://docs.figshare.com/#private_institution_articles
+
+        :return: Relational database of all articles for an institution
         """
 
         url = self.endpoint("articles")
@@ -85,6 +93,10 @@ class FigshareInstituteAdmin:
         associated with the user.
 
         See: https://docs.figshare.com/#private_articles_list
+
+        :param account_id: Figshare account ID
+
+        :return: Relational database of all articles owned by user
         """
 
         url = self.endpoint("articles", institute=False)
@@ -102,6 +114,10 @@ class FigshareInstituteAdmin:
         associated with the user.
 
         See: https://docs.figshare.com/#private_projects_list
+
+        :param account_id: Figshare account ID
+
+        :return: Relational database of all projects owned by user
         """
 
         url = self.endpoint("projects", institute=False)
@@ -119,6 +135,10 @@ class FigshareInstituteAdmin:
         associated with the user.
 
         See: https://docs.figshare.com/#private_collections_list
+
+        :param account_id: Figshare account ID
+
+        :return: Relational database of all collections owned by user
         """
 
         url = self.endpoint("collections", institute=False)
@@ -135,6 +155,8 @@ class FigshareInstituteAdmin:
         Retrieve information about groups within institutional instance.
 
         See: https://docs.figshare.com/#private_institution_groups_list
+
+        :return: Relational database of all Figshare groups for an institution
         """
 
         url = self.endpoint("groups")
@@ -148,6 +170,8 @@ class FigshareInstituteAdmin:
         Return pandas DataFrame of user accounts.
 
         See: https://docs.figshare.com/#private_institution_accounts_list
+
+        :return: Relational database of all user accounts for an institution
         """
 
         url = self.endpoint("accounts")
@@ -175,6 +199,10 @@ class FigshareInstituteAdmin:
         Retrieve group roles for a given account, ``account_id``.
 
         See: https://docs.figshare.com/#private_institution_account_group_roles
+
+        :param account_id: Figshare account ID
+
+        :return: Python dictionary of all group roles for a user
         """
 
         url = self.endpoint(f"roles/{account_id}")
@@ -184,8 +212,13 @@ class FigshareInstituteAdmin:
 
     def get_account_details(self, flag: bool = True) -> pd.DataFrame:
         """
-        Retrieve account details. This includes number of articles, projects,
-        collections, group association, and administrative and reviewer flags
+        Retrieve account details. This includes group association, number of
+        articles, projects, and collections, and administrative and reviewer
+        role flags
+
+        :param flag: Populate administrative and reviewer roles to database
+
+        :return: Relational database of details of all accounts for an institution
         """
 
         # Retrieve accounts
@@ -265,6 +298,10 @@ class FigshareInstituteAdmin:
         If not specified, all curation records are retrieved.
 
         See: https://docs.figshare.com/#account_institution_curations
+
+        :param article_id: Figshare article ID
+
+        :return: Relational database of all curation records
         """
 
         url = self.endpoint("reviews")
@@ -284,6 +321,10 @@ class FigshareInstituteAdmin:
         Retrieve details about a specified curation, ``curation_id``.
 
         See: https://docs.figshare.com/#account_institution_curation
+
+        :param curation_id: Figshare curation ID
+
+        :return: Python dictionary with curation metadata
         """
 
         url = self.endpoint(f"review/{curation_id}")
@@ -296,6 +337,10 @@ class FigshareInstituteAdmin:
         Retrieve comments about specified curation, ``curation_id``.
 
         See: https://docs.figshare.com/#account_institution_curation_comments
+
+        :param curation_id: Figshare curation ID
+
+        :return: Python dictionary with curation comments
         """
 
         url = self.endpoint(f"review/{curation_id}/comments")
@@ -308,6 +353,10 @@ class FigshareInstituteAdmin:
         Check if DOI is present/reserved for ``article_id``.
 
         Uses: https://docs.figshare.com/#private_article_details
+
+        :param article_id: Figshare article ID
+
+        :return: Flag to indicate whether DOI is reserved and DOI (empty string if not)
         """
         url = self.endpoint(f"articles/{article_id}", institute=False)
 
@@ -322,7 +371,12 @@ class FigshareInstituteAdmin:
     def reserve_doi(self, article_id: int) -> str:
         """
         Reserve DOI if one has not been reserved for ``article_id``.
+
         See: https://docs.figshare.com/#private_article_reserve_doi
+
+        :param article_id: Figshare article ID
+
+        :return: DOI string
         """
 
         url = self.endpoint(f"articles/{article_id}/reserve_doi",


### PR DESCRIPTION
Closes #10

Commit history:
- Add sphinx-build Github Action [ci skip]
- Add main Sphinx content (mostly from README.txt)
- Minor fix in sphinx-build GitHub action [ci skip]
- Add API documentation rst files
- Update docstrings for sphinx docs
- Change sub-heading in ldcool_figshare
- Update docstrings for sphinx
- Add content for use_examples page
