### PR TITLE
Update README.md with RTDs information and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@
 - [Authors](#authors)
 - [License](#license)
 
---------------
-
-## Overview
+Our complete Sphinx documentation is available
+[here](https://ldcoolp-figshare.readthedocs.io) at ReadTheDocs.io.
 
 `ldcoolp-figshare` is a command-line API used in
 [`LD-Cool-P`](https://github.com/UAL-ODIS/LD_Cool_P) to interact with the
@@ -27,50 +26,18 @@ other curators with a
 [Figshare for Institution](https://knowledge.figshare.com/institutions)
 instance can use.
 
-## Getting Started
+---
 
-You will need Python. We recommend v3.9.
-This code will be tested with v3.7, v3.8, and v3.9.
-
-This code will be published as `ldcoolp-figshare` on PyPI. Thus, the
-simplest installation will be:
-```
-pip install ldcoolp-figshare
-```
-
-### Requirements
-
-All requirements will be given in the [requirements.txt](requirements.txt)
-
-## Execution
-
-Under construction.
-
-## Versioning
-
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the
-[tags on this repository](https://github.com/UAL-ODIS/ldcoolp-figshare/tags).
-
-Releases will be auto-generated using this [GitHub Actions script](.github/workflows/create_release.yml)
-following a `git tag` version.
-
-## Continuous Integration
-
-Under construction
-
-## Changelog
-
-See the [CHANGELOG](CHANGELOG.md)
-
-
-## Authors
-
-* Chun Ly, Ph.D. ([@astrochun](http://www.github.com/astrochun)) - [University of Arizona Libraries](https://github.com/ualibraries), [Office of Digital Innovation and Stewardship](https://github.com/UAL-ODIS)
-
-See also the list of
-[contributors](https://github.com/UAL-ODIS/ldcoolp-figshare/contributors) who participated in this project.
-
-
-## License
-
-This project is licensed under the [MIT License](https://opensource.org/licenses/MIT) - see the [LICENSE](LICENSE) file for details.
+- [Getting Started](https://ldcoolp-figshare.readthedocs.io/en/latest/getting_started.html)
+    - [Requirements](https://ldcoolp-figshare.readthedocs.io/en/latest/getting_started.html#requirements)
+- [Use Examples](https://ldcoolp-figshare.readthedocs.io/en/latest/use_examples.html)
+    - [Get a list of accounts](https://ldcoolp-figshare.readthedocs.io/en/latest/use_examples.html#get-a-list-of-accounts)
+    - [Obtain curation records](https://ldcoolp-figshare.readthedocs.io/en/latest/use_examples.html#obtain-curation-records)
+    - [DOI status and reservation](https://ldcoolp-figshare.readthedocs.io/en/latest/use_examples.html#doi-status-and-reservation)
+    - [Retrieve list of institution groups](https://ldcoolp-figshare.readthedocs.io/en/latest/use_examples.html#retrieve-list-of-institution-groups)
+    - [Retrieve list of articles for a user](https://ldcoolp-figshare.readthedocs.io/en/latest/use_examples.html#retrieve-list-of-articles-for-a-user)
+- [Continuous Integration](https://ldcoolp-figshare.readthedocs.io/en/latest/ci.html)
+- [Versioning](https://ldcoolp-figshare.readthedocs.io/en/latest/versioning.html)
+- [Authors](https://ldcoolp-figshare.readthedocs.io/en/latest/authors.html)
+- [License](https://ldcoolp-figshare.readthedocs.io/en/latest/license.html)
+- [API Documentation](https://ldcoolp-figshare.readthedocs.io/en/latest/modules.html)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,10 @@
 # LD-Cool-P Figshare API Tool
 
-![GitHub top language](https://img.shields.io/github/languages/top/UAL-ODIS/ldcoolp-figshare)
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/UAL-ODIS/ldcoolp-figshare)
-![GitHub](https://img.shields.io/github/license/UAL-ODIS/ldcoolp-figshare?color=blue)
-
-- [Overview](#overview)
-- [Getting Started](#getting-started)
-    - [Requirements](#requirements)
-- [Execution](#execution)
-- [Versioning](#versioning)
-- [Continuous Integration](#continuous-integration)
-- [Changelog](#changelog)
-- [Authors](#authors)
-- [License](#license)
+| Categories | Status |
+| ---        | ---    |
+| General    | ![GitHub top language](https://img.shields.io/github/languages/top/UAL-ODIS/ldcoolp-figshare) [![GitHub release (latest by date)](https://img.shields.io/github/v/release/UAL-ODIS/ldcoolp-figshare)](https://github.com/UAL-ODIS/ldcoolp-figshare/releases) [![GitHub](https://img.shields.io/github/license/UAL-ODIS/ldcoolp-figshare?color=blue)](LICENSE) |
+| CI/CD      | Under construction | 
+| Docs       | [![docs](https://img.shields.io/github/workflow/status/UAL-ODIS/ldcoolp-figshare/Sphinx%20Docs%20Check?label=sphinx%20docs)](https://github.com/UAL-ODIS/ldcoolp-figshare/actions?query=workflow%3A%22Sphinx+Docs+Check%22) [![Read the Docs](https://img.shields.io/readthedocs/ldcoolp-figshare?label=RTDs)](https://readthedocs.org/projects/ldcoolp-figshare/builds) |
 
 Our complete Sphinx documentation is available
 [here](https://ldcoolp-figshare.readthedocs.io) at ReadTheDocs.io.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,16 @@
 Welcome to :repo:`ldcoolp-figshare <>` documentation!
 =====================================================
 
-|GitHub top language| |GitHub release (latest by date)| |GitHub|
++------------+--------------------------------------------+
+| Categories | Status                                     |
++============+============================================+
+| General    | |GitHub top language|                      |
+|            | |GitHub release (latest by date)| |GitHub| |
++------------+--------------------------------------------+
+| CI/CD      | Under construction                         |
++------------+--------------------------------------------+
+| Docs       | |docs| |Read the Docs|                     |
++------------+------------------------------+-------------+
 
 --------------
 
@@ -33,7 +42,12 @@ instance can use.
 
 .. |GitHub top language| image:: https://img.shields.io/github/languages/top/UAL-ODIS/ldcoolp-figshare
 .. |GitHub release (latest by date)| image:: https://img.shields.io/github/v/release/UAL-ODIS/ldcoolp-figshare
+   :target: https://github.com/UAL-ODIS/ldcoolp-figshare/releases
 .. |GitHub| image:: https://img.shields.io/github/license/UAL-ODIS/ldcoolp-figshare?color=blue
+   :target: LICENSE
+.. |docs| image:: https://img.shields.io/github/workflow/status/UAL-ODIS/ldcoolp-figshare/Sphinx%20Docs%20Check?label=sphinx%20docs
+   :target: https://github.com/UAL-ODIS/ldcoolp-figshare/actions?query=workflow%3A%22Sphinx+Docs+Check%22
+.. |Read the Docs| image:: https://img.shields.io/readthedocs/ldcoolp-figshare?label=RTDs
 
 .. _LD-Cool-P: https://github.com/UAL-ODIS/LD_Cool_P
 .. _Figshare API: https://api.figshare.com


### PR DESCRIPTION
Closes #12

Commit history:
- Simplify README.md to point to RTDs [ci skip]
- Adjust GitHub badges header with markdown table
- Use rST table for GitHub badges in index.rst
