### PR TITLE
Remove GitHub badges from RTDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 
-## [UNRELEASED](https://github.com/UAL-ODIS/ldcoolp-figshare/tree/HEAD) (YYYY-MM-DD)
+## [v0.2.2](https://github.com/UAL-ODIS/ldcoolp-figshare/tree/v0.2.2) (2021-06-03)
 
 **Implemented enhancements:**
  - For get_curation_list method, allow for pending selection [#21](http://github.com/UAL-ODIS/ldcoolp-figshare/pull/21)
+ 
+**Fixed bugs:**
+ - Remove GitHub badges from RTDs [#20](http://github.com/UAL-ODIS/ldcoolp-figshare/issues/20)
 
 **Closed issues:**
  - For get_curation_list method, allow for pending selection [#19](http://github.com/UAL-ODIS/ldcoolp-figshare/issues/19)
+
+**Merged pull requests:**
+ - Remove GitHub badges from RTDs [#22](http://github.com/UAL-ODIS/ldcoolp-figshare/pull/22)
 
 
 ## [v0.2.0](https://github.com/UAL-ODIS/ldcoolp-figshare/tree/HEAD) (2021-05-24)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = '2021, Arizona Board of Regents'
 author = 'Chun Ly, UA Research Data Repository (ReDATA) Team'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.2.1'
+release = 'v0.2.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,21 +6,6 @@
 Welcome to :repo:`ldcoolp-figshare <>` documentation!
 =====================================================
 
-+------------+--------------------------------------------+
-| Categories | Status                                     |
-+============+============================================+
-| General    | |PyPI - Python Version|                    |
-|            | |GitHub release (latest by date)| |GitHub| |
-+------------+--------------------------------------------+
-| CI/CD      | Under construction                         |
-+------------+--------------------------------------------+
-| PyPI       | |PyPI|                                     |
-|            | |PyPI - Weekly Downloads|                  |
-|            | |PyPI - Monthly Downloads|                 |
-+------------+--------------------------------------------+
-| Docs       | |docs| |Read the Docs|                     |
-+------------+--------------------------------------------+
-
 --------------
 
 Overview
@@ -43,19 +28,6 @@ instance can use.
    authors
    license
    modules
-
-.. |GitHub release (latest by date)| image:: https://img.shields.io/github/v/release/UAL-ODIS/ldcoolp-figshare
-   :target: https://github.com/UAL-ODIS/ldcoolp-figshare/releases
-.. |GitHub| image:: https://img.shields.io/github/license/UAL-ODIS/ldcoolp-figshare?color=blue
-   :target: LICENSE
-.. |PyPI - Python Version| image:: https://img.shields.io/pypi/pyversions/ldcoolp-figshare
-.. |PyPI| image:: https://img.shields.io/pypi/v/ldcoolp-figshare?color=blue
-   :target: https://pypi.org/project/ldcoolp-figshare/
-.. |PyPI - Weekly Downloads| image:: https://img.shields.io/pypi/dw/ldcoolp-figshare?color=blue
-.. |PyPI - Monthly Downloads| image:: https://img.shields.io/pypi/dm/ldcoolp-figshare?color=blue
-.. |docs| image:: https://img.shields.io/github/workflow/status/UAL-ODIS/ldcoolp-figshare/Sphinx%20Docs%20Check?label=sphinx%20docs
-   :target: https://github.com/UAL-ODIS/ldcoolp-figshare/actions?query=workflow%3A%22Sphinx+Docs+Check%22
-.. |Read the Docs| image:: https://img.shields.io/readthedocs/ldcoolp-figshare?label=RTDs
 
 .. _LD-Cool-P: https://github.com/UAL-ODIS/LD_Cool_P
 .. _Figshare API: https://api.figshare.com

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,8 +6,6 @@
 Welcome to :repo:`ldcoolp-figshare <>` documentation!
 =====================================================
 
---------------
-
 Overview
 --------
 

--- a/ldcoolp_figshare/__init__.py
+++ b/ldcoolp_figshare/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 from .main import FigshareInstituteAdmin

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fr:
 
 setup(
     name='ldcoolp-figshare',
-    version='0.2.1',
+    version='0.2.2',
     packages=find_namespace_packages(),
     url='https://github.com/UAL-ODIS/ldcoolp-figshare/',
     project_urls={


### PR DESCRIPTION
Closes #20

- Remove badges from sphinx docs
- Bump version: v0.2.1 -> v0.2.2
